### PR TITLE
apiKey -> secretKey in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ They are all referenced by `stripe.<resource>` and can be used like so:
 
 ```js
 var stripe = require('feathers-stripe');
-app.use('/stripe/charges', stripe.charge({ apiKey: 'your api key' }));
+app.use('/stripe/charges', stripe.charge({ secretKey: 'your secret stripe key' }));
 ```
 
 #### Webhooks
@@ -119,7 +119,7 @@ var app = feathers()
   .use(bodyParser.json())
   .use(bodyParser.urlencoded({ extended: true }))
   // A simple Message service that we can used for testing
-  .use('/stripe/charges', stripe.charge({ apiKey: 'your api key' }))
+  .use('/stripe/charges', stripe.charge({ secretKey: 'your secret stripe key' }))
   .use('/', feathers.static(__dirname + '/public'))
   .use(errorHandler({ html: false }));
 


### PR DESCRIPTION
Very simple PR, just changing `apiKey` in the README to `secretKey` as per the source. 
