### PR TITLE
Add support for external accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following services are supported and map to the appropriate Stripe resource:
 - `customerSubscription`
 - `dispute`
 - `event`
+- `externalAccount`
 - `invoiceItem`
 - `invoice`
 - `order`

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import charge from './services/charge';
 import coupon from './services/coupon';
 import customer from './services/customer';
 import dispute from './services/dispute';
+import externalAccount from './services/external-account';
 import event from './services/event';
 import invoice from './services/invoice';
 import invoiceItem from './services/invoice-item';
@@ -33,6 +34,7 @@ export default {
   customer,
   dispute,
   event,
+  externalAccount,
   invoice,
   invoiceItem,
   order,

--- a/src/services/external-account.js
+++ b/src/services/external-account.js
@@ -1,0 +1,76 @@
+import errorHandler from '../error-handler';
+import normalizeQuery from '../normalize-query';
+import makeDebug from 'debug';
+import Stripe from 'stripe';
+
+const debug = makeDebug('feathers-stripe:external-account');
+
+class Service {
+  constructor (options = {}) {
+    if (!options.secretKey) {
+      throw new Error('Stripe `secretKey` needs to be provided');
+    }
+
+    this.stripe = Stripe(options.secretKey);
+    this.paginate = options.paginate = {};
+  }
+
+  find (params) {
+    if (!params || !params.account) {
+      debug('Missing Stripe account id');
+    }
+    // TODO (EK): Handle pagination
+    const query = normalizeQuery(params);
+    return this.stripe.accounts
+      .listExternalAccounts(params.account, query)
+      .catch(errorHandler);
+  }
+
+  get (id, params) {
+    if (!params || !params.account) {
+      debug('Missing Stripe account id');
+    }
+    return this.stripe.customers
+      .retrieveExternalAccount(params.account, id)
+      .catch(errorHandler);
+  }
+
+  create (data, params) {
+    if (!params || !params.account) {
+      debug('Missing Stripe account id');
+    }
+    return this.stripe.accounts
+      .createExternalAccount(params.account, data)
+      .catch(errorHandler);
+  }
+
+  patch (...args) {
+    return this.update(...args);
+  }
+
+  update (id, data, params) {
+    if (!params || !params.account) {
+      debug('Missing Stripe account id');
+    }
+    return this.stripe.accounts
+      .updateExternalAccount(params.account, id, data)
+      .catch(errorHandler);
+  }
+
+  remove (id, params) {
+    if (!params || !params.account) {
+      debug('Missing Stripe account id');
+    }
+    return this.stripe.accounts
+      .deleteExternalAccount(params.account, id)
+      .catch(errorHandler);
+  }
+}
+
+export default function init (options) {
+  debug('Initializing feathers-stripe:external-account plugin');
+
+  return new Service(options);
+}
+
+init.Service = Service;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,6 +46,10 @@ describe('feathers-stripe', () => {
     expect(typeof stripe.event).to.equal('function');
   });
 
+  it('supports external accounts', () => {
+    expect(typeof stripe.externalAccount).to.equal('function');
+  });
+
   it('supports invoiceItems', () => {
     expect(typeof stripe.invoiceItem).to.equal('function');
   });


### PR DESCRIPTION
### Summary

This pull request adds support for stripe connect external accounts (https://stripe.com/docs/api#external_accounts). The stripe account is provided via `params.account`, similarly to the relationship between card and customer. 