### PR TITLE
Payouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following services are supported and map to the appropriate Stripe resource:
 - `invoiceItem`
 - `invoice`
 - `order`
+- `payout`
 - `plan`
 - `product`
 - `recipient`

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ import event from './services/event';
 import invoice from './services/invoice';
 import invoiceItem from './services/invoice-item';
 import order from './services/order';
+import payout from './services/payout';
 import plan from './services/plan';
 import product from './services/product';
 import recipient from './services/recipient';
@@ -36,6 +37,7 @@ export default {
   invoice,
   invoiceItem,
   order,
+  payout,
   plan,
   product,
   recipient,

--- a/src/services/payout.js
+++ b/src/services/payout.js
@@ -1,0 +1,54 @@
+import errorHandler from '../error-handler';
+import normalizeQuery from '../normalize-query';
+import makeDebug from 'debug';
+import Stripe from 'stripe';
+
+const debug = makeDebug('feathers-stripe:payout');
+
+class Service {
+  constructor (options = {}) {
+    if (!options.secretKey) {
+      throw new Error('Stripe `secretKey` needs to be provided');
+    }
+
+    this.stripe = Stripe(options.secretKey);
+    this.paginate = options.paginate = {};
+  }
+
+  find (params) {
+    // TODO (EK): Handle pagination
+    const query = normalizeQuery(params);
+    return this.stripe.payouts.list(query).catch(errorHandler);
+  }
+
+  get (id) {
+    return this.stripe.payouts.retrieve(id).catch(errorHandler);
+  }
+
+  create (data) {
+    // Pull out stripe connect arguments
+    const { connect = {} } = data;
+
+    return this.stripe.payouts.create(data, connect).catch(errorHandler);
+  }
+
+  patch (...args) {
+    return this.update(...args);
+  }
+
+  update (id, data) {
+    return this.stripe.payouts.update(id, data).catch(errorHandler);
+  }
+
+  remove (id) {
+    return this.stripe.payouts.close(id).catch(errorHandler);
+  }
+}
+
+export default function init (options) {
+  debug('Initializing feathers-stripe:payout plugin');
+
+  return new Service(options);
+}
+
+init.Service = Service;

--- a/src/services/payout.js
+++ b/src/services/payout.js
@@ -29,6 +29,9 @@ class Service {
     // Pull out stripe connect arguments
     const { connect = {} } = data;
 
+    // Remove connect from main arguments
+    delete data.connect;
+
     return this.stripe.payouts.create(data, connect).catch(errorHandler);
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,6 +58,10 @@ describe('feathers-stripe', () => {
     expect(typeof stripe.order).to.equal('function');
   });
 
+  it('supports payouts', () => {
+    expect(typeof stripe.payout).to.equal('function');
+  });
+
   it('supports plans', () => {
     expect(typeof stripe.plan).to.equal('function');
   });


### PR DESCRIPTION
## Description

This pull requests adds support for the renamed transfers endpoint payouts (https://stripe.com/docs/api#payouts) which is only valid for the newest version of the api, but should work anyway.

One small wrinkle is that connected accounts are supported through the `connect` key on data, which may or may not be the best solution.

Apologies for the small scale PRs, I'll work on full connect support when I have a little bit of time.

Thanks!