### PR TITLE
Update error handler so original error message is supplied in data

### DIFF
--- a/lib/error-handler.js
+++ b/lib/error-handler.js
@@ -1,33 +1,36 @@
 const errors = require('@feathersjs/errors');
 
-module.exports = function errorHandler (error) {
+module.exports = function errorHandler(error) {
   let feathersError = error;
 
   if (error.type) {
     switch (error.type) {
       case 'StripeCardError':
         // A declined card error
-        feathersError = new errors.PaymentError(error);
+        feathersError = new errors.PaymentError(error, error);
         break;
       case 'StripeInvalidRequestError':
       case 'StripeInvalidRequest':
         // Invalid parameters were supplied to Stripe's API
-        feathersError = new errors.BadRequest(error);
+        feathersError = new errors.BadRequest(error, error);
         break;
       case 'StripeAPIError':
         // An error occurred internally with Stripe's API
-        feathersError = new errors.Unavailable(error);
+        feathersError = new errors.Unavailable(error, error);
         break;
       case 'StripeConnectionError':
         // Some kind of error occurred during the HTTPS communication
-        feathersError = new errors.Unavailable(error);
+        feathersError = new errors.Unavailable(error, error);
         break;
       case 'StripeAuthenticationError':
         // You probably used an incorrect API key
-        feathersError = new errors.NotAuthenticated(error);
+        feathersError = new errors.NotAuthenticated(error, error);
         break;
       default:
-        feathersError = new errors.GeneralError('Unknown Payment Gateway Error', error);
+        feathersError = new errors.GeneralError(
+          'Unknown Payment Gateway Error',
+          error
+        );
     }
   }
 


### PR DESCRIPTION
### Summary

(If you have not already please refer to the contributing guideline as [described
here](https://github.com/feathersjs/feathers/blob/master/.github/contributing.md#pull-requests))

- [ ] Tell us about the problem your pull request is solving.
- [ ] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

To resolve issue https://github.com/feathersjs-ecosystem/feathers-stripe/issues/27 

The current error handler strips out a lot of the Stripe error details, so if you need to manipulate a particular error it's not possible as it becomes a generic Payment Error bar the message. This PR make the original error available in the data field.