### PR TITLE
#64 Query Account Balances

### DIFF
--- a/lib/services/balance.js
+++ b/lib/services/balance.js
@@ -2,14 +2,16 @@ const Base = require('./base');
 const errorHandler = require('../error-handler');
 
 module.exports = class Service extends Base {
-  find () {
-    // TODO (EK): Handle pagination
-    // NOTE (EK): Stripe doesn't accept params for this method
+  find (params) {
+    if (params && params.query) {
+      return this.stripe.balance.retrieve(params.query).catch(errorHandler);
+    }
     return this.stripe.balance.retrieve().catch(errorHandler);
   }
 
-  get () {
-    // NOTE (EK): Stripe doesn't accept params for this method
-    return this.stripe.balance.retrieve().catch(errorHandler);
+  get (stripe_account) {
+    return this.stripe.balance.retrieve({
+      stripe_account
+    }).catch(errorHandler);
   }
 };

--- a/lib/services/balance.js
+++ b/lib/services/balance.js
@@ -9,9 +9,9 @@ module.exports = class Service extends Base {
     return this.stripe.balance.retrieve().catch(errorHandler);
   }
 
-  get (stripe_account) {
+  get (id) {
     return this.stripe.balance.retrieve({
-      stripe_account
+      stripe_account: id
     }).catch(errorHandler);
   }
 };


### PR DESCRIPTION
Solves #64 - Allow fetching account balance of other accounts.

This actually solves a bug on the `Balance` service as well. In the current state of the master branch, the balance service's `get()` method does not have an `id` argument (because it wasn't passed to underlying stripe method). But, this actually throws an `An id must be provided to the 'get' method`, so that method is currently not working at all.

So the new `get()` method requires and uses an id parameter by passing it to the underlying stripe method, instead of it just "defaulting" to the account in which the stripe keys belong to (your own account). And that seems more restful. You have to use an id with GET request.

The `find()` method will now accept `params.query` and pass those to the underlying stripe method. But, you can omit the query and retrieve the "default" of your own account balance.

I also removed the `// TODO` about pagination because I don't believe there is pagination on the balance result.