### PR TITLE
Migration for stripe v7 balance transaction

### DIFF
--- a/lib/services/transaction.js
+++ b/lib/services/transaction.js
@@ -6,10 +6,10 @@ module.exports = class Service extends Base {
   find (params) {
     // TODO (EK): Handle pagination
     const query = normalizeQuery(params);
-    return this.stripe.balance.listTransactions(query).catch(errorHandler);
+    return this.stripe.balanceTransactions.list(query).catch(errorHandler);
   }
 
   get (id) {
-    return this.stripe.balance.retrieveTransaction(id).catch(errorHandler);
+    return this.stripe.balanceTransactions.retrieve(id).catch(errorHandler);
   }
 };


### PR DESCRIPTION
### Summary

There is an error throwing while retrieving any balance transaction as given below due to incomplete migration to stripe version 7.

### Calling:

`await app.service('stripe/transactions').get('stripe transaction id');`

### Throws:

```
TypeError: this.stripe.balance.retrieveTransaction is not a function
    at Object.get (/Users/fazil/homelike/src/payments/node_modules/feathers-stripe/lib/services/transaction.js:13:32)
    at processHooks.call.then.hookObject (/Users/fazil/homelike/src/payments/node_modules/@feathersjs/feathers/lib/hooks/index.js:56:27)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:229:7)
    at Function.Module.runMain (module.js:696:11)
    at process.on (/Users/fazil/homelike/src/payments/node_modules/babel-watch/runner.js:108:21)
    at emitTwo (events.js:126:13)
    at process.emit (events.js:214:7)
    at emit (internal/child_process.js:762:12)
    at _combinedTickCallback (internal/process/next_tick.js:142:11)
    at process._tickCallback (internal/process/next_tick.js:181:9)
```

### Reason:

This is a side effect from newer version of stripe. Version 7 of stripe's Node.js library contains some backwards incompatible changes. Below are the changes in 'balance' api.

```
balance.listTransactions() => balanceTransactions.list()
balance.retrieveTransaction() => balanceTransactions.retrieve()
```

More details and other changes can be found here.

https://github.com/stripe/stripe-node/wiki/Migration-guide-for-v7

Since we are using stripe "^7.5.2", using old api will throw error. Please see my patch below.