### PR TITLE
Added stripe SetupIntent feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ The following services are supported and map to the appropriate Stripe resource:
 - `Invoice`
 - `Order`
 - `Payout`
+- `PaymentIntent`
 - `PaymentMethod`
 - `Plan`
 - `Product`
 - `Recipient`
 - `Refund`
+- `SetupIntent`
 - `Sku`
 - `Source`
 - `Subscription`

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ const Plan = require('./services/plan');
 const Product = require('./services/product');
 const Recipient = require('./services/recipient');
 const Refund = require('./services/refund');
+const SetupIntent = require('./services/setup-intent');
 const Sku = require('./services/sku');
 const Source = require('./services/source');
 const Subscription = require('./services/subscription');
@@ -48,6 +49,7 @@ module.exports = {
   Product,
   Recipient,
   Refund,
+  SetupIntent,
   Sku,
   Source,
   Subscription,

--- a/lib/services/setup-intent.js
+++ b/lib/services/setup-intent.js
@@ -1,0 +1,27 @@
+const errorHandler = require('../error-handler');
+const normalizeQuery = require('../normalize-query');
+const Base = require('./base');
+
+module.exports = class Service extends Base {
+  find (params) {
+    // TODO: Handle pagination
+    const query = normalizeQuery(params);
+    return this.stripe.setupIntents.list(query).catch(errorHandler);
+  }
+
+  get (id) {
+    return this.stripe.setupIntents.retrieve(id).catch(errorHandler);
+  }
+
+  create (data) {
+    return this.stripe.setupIntents.create(data).catch(errorHandler);
+  }
+
+  patch (id, data) {
+    return this.update(id, data);
+  }
+
+  update (id, data) {
+    return this.stripe.setupIntents.update(id, data).catch(errorHandler);
+  }
+};


### PR DESCRIPTION
### Summary

Added stripe SetupIntent service. We already have PaymentIntent service which is very useful for an on-session payment. But to save a card for future usage, stripe recommends SetupIntent api which we don't currently have in our ecosystem. Please see below reference to know more about on saving cards and use it in off-session using SetupIntent api.

https://stripe.com/docs/payments/cards/reusing-cards

So I copied SetupIntent service from existing PaymentIntent service and changed it little bit. Since we don't have any tests for PaymentIntent, I didn't add any for SetupIntent either. Though I have done a local development test of all the methods.