### PR TITLE
uses new stripe initializaiton style with key and config

### DIFF
--- a/lib/services/base.js
+++ b/lib/services/base.js
@@ -1,12 +1,12 @@
 const Stripe = require('stripe');
 
 module.exports = class BaseService {
-  constructor (options = {}) {
-    if (!options.secretKey) {
+  constructor (secretKey, config = {}) {
+    if (!secretKey) {
       throw new Error('Stripe `secretKey` needs to be provided');
     }
 
-    this.stripe = Stripe(options.secretKey);
+    this.stripe = Stripe(secretKey, config);
     this.paginate = options.paginate = {};
     this.id = 'id';
   }

--- a/lib/services/base.js
+++ b/lib/services/base.js
@@ -2,12 +2,17 @@ const Stripe = require('stripe');
 
 module.exports = class BaseService {
   constructor (secretKey, config = {}) {
+    // If first parameter is an object, we assume the old behavior of passing in secretKey
+    if(typeof secretKey === 'object') {
+      secretKey = secretKey.secretKey;
+      this.paginate = secretKey.paginate;
+    }
+
     if (!secretKey) {
       throw new Error('Stripe `secretKey` needs to be provided');
     }
 
     this.stripe = Stripe(secretKey, config);
-    this.paginate = options.paginate = {};
     this.id = 'id';
   }
 };


### PR DESCRIPTION
## This PR allows passing additional configuration to Stripe

```javascript
 import * as stripe from 'feathers-stripe';

 app.use('/stripe/sources', new stripe.Source(secretKey, {apiVersion: '2019-12-03'}));
```
Still supports older way of passing secretKey 
```javascript
 import * as stripe from 'feathers-stripe';

 app.use('/stripe/sources', new stripe.Source({ secretKey: 'msec_asdi12NIOEBFLE' }));