### PR TITLE
Add webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following services are supported and map to the appropriate Stripe resource:
 - `Transaction`
 - `Transfer`
 - `TransferReversal`
+- `Webhook`
 
 
 **This is pretty important!** Since this connects to your Stripe account you want to make sure that you don't expose these endpoints via your app unless the user has the appropriate permissions. You can prevent any external access by doing this:
@@ -133,6 +134,39 @@ chargeService.create(charge).then(result => {
 app.listen(3030);
 
 console.log('Feathers authentication app started on 127.0.0.1:3030');
+```
+
+## Webhook
+
+You can setup a webhook using the helper function `setupWebhook` in your service
+
+setupWebhook: (app, route, {
+  endpointSecret: 'webhook-endpoint-secret',
+  secretKey: 'your-secret-key'
+  handlers: {}
+})
+
+```js
+module.exports = function (app) {
+  setupWebhook(app, '/stripe-webhook', {
+    endpointSecret: 'whsec_ededqwdwqdqwdqwd778qwdwqdq',
+    secretKey: 'sk_test_OINqdwqdE89EFqdwwdwqdqdWDQ',
+    handlers: {
+      customer: {
+        subscription: {
+          async created({ object, event, params, app }) {
+            return {};
+          }
+        }
+      }
+    }
+  });
+
+  // Get our initialized service so that we can register hooks
+  const service = app.service('stripe-webhook');
+
+  service.hooks(hooks);
+};
 ```
 
 ## License

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,17 @@ const Token = require('./services/token');
 const Transaction = require('./services/transaction');
 const Transfer = require('./services/transfer');
 const TransferReversal = require('./services/transfer-reversal');
+const Webhook = require('./services/webhook');
+
+function setupWebhook (app, route, { endpointSecret, secretKey, handlers }) {
+  app.use(route, new Webhook({
+    route,
+    handlers,
+    secretKey,
+    app,
+    endpointSecret
+  }));
+}
 
 module.exports = {
   Account,
@@ -59,5 +70,7 @@ module.exports = {
   Token,
   Transaction,
   Transfer,
-  TransferReversal
+  TransferReversal,
+  Webhook,
+  setupWebhook
 };

--- a/lib/services/webhook.js
+++ b/lib/services/webhook.js
@@ -1,0 +1,55 @@
+// Heavily inspired from https://github.com/fixate/feathers-stripe-webhooks
+const Base = require('./base');
+
+module.exports = class Webhook extends Base {
+  constructor (options = {}) {
+    super(options);
+
+    if (!options.app) {
+      throw new Error('options.app is required');
+    }
+
+    this.app = options.app;
+    this.handlers = options.handlers || {};
+
+    this.app.post(options.route, (req, res, next) => {
+      const signature = req.headers['stripe-signature'];
+      if (!signature) {
+        res.status(400).end('Bad signature');
+        return;
+      }
+
+      try {
+        this.stripe.webhooks.constructEvent(req.rawBody, signature, options.endpointSecret);
+      } catch (err) {
+        res.status(400).end(err);
+        return;
+      }
+
+      next();
+    });
+  }
+
+  getHandler (event) {
+    const parts = event.type.split('.');
+    let node = this.handlers;
+
+    for (const p in parts) {
+      node = node[parts[p]];
+
+      if (!node) { return null; }
+    }
+
+    return node;
+  }
+
+  create (event, params) {
+    const handler = this.getHandler(event);
+    if (!handler) {
+      // No handler, nothing to do
+      return Promise.resolve({});
+    }
+
+    return handler({ object: event.data.object, event, params, app: this.app });
+  }
+};

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,7 +25,9 @@ const CLASSES = ['Account',
   'Token',
   'Transaction',
   'Transfer',
-  'TransferReversal'
+  'TransferReversal',
+  'Webhook',
+  'setupWebhook'
 ];
 
 describe('feathers-stripe', () => {


### PR DESCRIPTION
### Summary

Hello, 

I added a new class for the stripe webhook, with a helper function to make it easier to set it up. Heavily inspired from https://github.com/fixate/feathers-stripe-webhooks

I didn't wanted to include an other library to handle the webhook. Like that I can handle my global variable/stripe lib the same way.

Found an old issue here:
https://github.com/feathersjs-ecosystem/feathers-stripe/issues/8

### Other Information

I added the signature check middleware directly to the Webhook class so that feather can read the header.

EDIT:

It need 
```
verify: function (req, res, buf) {
    var url = req.originalUrl;
    if (url.startsWith(route)) {
      req.rawBody = buf.toString();
    }
  }
```
because of the json body parser.