### PR TITLE
Fixes sample code for preventing external access

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,16 @@ The following services are supported and map to the appropriate Stripe resource:
 ```js
 const { Forbidden } = require('@feathersjs/errors');
 
-app.service('/stripe/charges').before({
-  all: [
-    context => {
-      if(context.params.provider) {
-        throw new Forbidden('You are not allowed to access this');
+app.service('/stripe/charges').hooks({
+  before: {
+    all: [
+      context => {
+        if(context.params.provider) {
+          throw new Forbidden('You are not allowed to access this');
+        }
       }
-    }
-  ]
+    ]
+  }
 });
 ```
 


### PR DESCRIPTION
The old sample code triggered an error, probably an old feathersjs syntax.

However I don't get if this is useful because before adding the hook, http://localhost:3030/stripe/charges already replied with a 404.

