### PR TITLE
Pass data forward on capture

### DIFF
--- a/lib/services/charge.js
+++ b/lib/services/charge.js
@@ -19,7 +19,8 @@ module.exports = class Service extends Base {
 
   patch (id, data) {
     if (data.capture) {
-      return this.stripe.charges.capture(id).catch(errorHandler);
+      delete data.capture;
+      return this.stripe.charges.capture(id, data).catch(errorHandler);
     }
 
     return this.update(id, data);

--- a/lib/services/charge.js
+++ b/lib/services/charge.js
@@ -17,9 +17,10 @@ module.exports = class Service extends Base {
     return this.stripe.charges.create(data).catch(errorHandler);
   }
 
-  patch (id, data) {
-    if (data.capture) {
-      delete data.capture;
+  patch (id, _data) {
+    const { capture, ...data } = data;
+    
+    if (capture) {
       return this.stripe.charges.capture(id, data).catch(errorHandler);
     }
 


### PR DESCRIPTION
### Summary

It is possible to specify other data parameters when capturing a payment. Importantly is the `amount` parameter, if this has changed from the original charge, it needs to be specified to release the difference in funds.

https://stripe.com/docs/api/charges/capture