### PR TITLE
Added stripe Application Fee Refunds feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The following services are supported and map to the appropriate Stripe resource:
 
 - `Account`
 - `AccountLinks`
+- `ApplicationFeeRefund`
 - `BankAccount`
 - `Balance`
 - `Card`

--- a/README.md
+++ b/README.md
@@ -47,11 +47,13 @@ The following services are supported and map to the appropriate Stripe resource:
 - `Invoice`
 - `Order`
 - `Payout`
+- `PaymentIntent`
 - `PaymentMethod`
 - `Plan`
 - `Product`
 - `Recipient`
 - `Refund`
+- `SetupIntent`
 - `Sku`
 - `Source`
 - `Subscription`

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const Account = require('./services/account');
 const AccountLinks = require('./services/account-links');
+const ApplicationFeeRefund = require('./services/application-fee-refund');
 const Balance = require('./services/balance');
 const BankAccount = require('./services/bank-account');
 const ExternalAccount = require('./services/external-account');
@@ -32,6 +33,7 @@ const TransferReversal = require('./services/transfer-reversal');
 module.exports = {
   Account,
   AccountLinks,
+  ApplicationFeeRefund,
   Balance,
   BankAccount,
   ExternalAccount,

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ const Plan = require('./services/plan');
 const Product = require('./services/product');
 const Recipient = require('./services/recipient');
 const Refund = require('./services/refund');
+const SetupIntent = require('./services/setup-intent');
 const Sku = require('./services/sku');
 const Source = require('./services/source');
 const Subscription = require('./services/subscription');
@@ -48,6 +49,7 @@ module.exports = {
   Product,
   Recipient,
   Refund,
+  SetupIntent,
   Sku,
   Source,
   Subscription,

--- a/lib/services/application-fee-refund.js
+++ b/lib/services/application-fee-refund.js
@@ -1,0 +1,40 @@
+const Base = require('./base');
+
+const errorHandler = require('../error-handler');
+const normalizeQuery = require('../normalize-query');
+
+module.exports = class Service extends Base {
+  find (params) {
+    if (!params || !params.fee) {
+      debug('Missing Stripe fee id');
+    }
+    // TODO (EK): Handle pagination
+    const query = normalizeQuery(params);
+    return this.stripe.applicationFees.listRefunds(params.fee, query).catch(errorHandler);
+  }
+
+  get (id, params) {
+    if (!params || !params.fee) {
+      debug('Missing Stripe fee id');
+    }
+    return this.stripe.applicationFees.retrieveRefund(params.fee, id).catch(errorHandler);
+  }
+
+  create (data, params) {
+    if (!params || !params.fee) {
+      debug('Missing Stripe fee id');
+    }
+    return this.stripe.applicationFees.createRefund(params.fee, data).catch(errorHandler);
+  }
+
+  patch (id, data, params) {
+    return this.update(id, data, params);
+  }
+
+  update (id, data, params) {
+    if (!params || !params.fee) {
+      debug('Missing Stripe fee id');
+    }
+    return this.stripe.applicationFees.updateRefund(params.fee, id, data).catch(errorHandler);
+  }
+};

--- a/lib/services/setup-intent.js
+++ b/lib/services/setup-intent.js
@@ -1,0 +1,27 @@
+const errorHandler = require('../error-handler');
+const normalizeQuery = require('../normalize-query');
+const Base = require('./base');
+
+module.exports = class Service extends Base {
+  find (params) {
+    // TODO: Handle pagination
+    const query = normalizeQuery(params);
+    return this.stripe.setupIntents.list(query).catch(errorHandler);
+  }
+
+  get (id) {
+    return this.stripe.setupIntents.retrieve(id).catch(errorHandler);
+  }
+
+  create (data) {
+    return this.stripe.setupIntents.create(data).catch(errorHandler);
+  }
+
+  patch (id, data) {
+    return this.update(id, data);
+  }
+
+  update (id, data) {
+    return this.stripe.setupIntents.update(id, data).catch(errorHandler);
+  }
+};


### PR DESCRIPTION
### Summary

Added stripe Application Fee Refunds service. We already have Refund service which is very useful for refunding a charge. But to refund an application fee alone to connected account, stripe provides Application Fee Refunds api which we don't currently have in our ecosystem. Please see below reference to know more about on Application Fee Refunds api.

https://stripe.com/docs/api/fee_refunds

So I copied ApplicationFeeRefund service from existing Refund service and changed it little bit. Since we don't have any tests for Refund, I didn't add any for Application Fee Refunds either. Though I have done a local development test of all the methods. I have added this to readme as well.