### PR TITLE
Add generic options to service

### DIFF
--- a/lib/services/base.js
+++ b/lib/services/base.js
@@ -6,6 +6,7 @@ module.exports = class BaseService {
       throw new Error('Stripe `secretKey` needs to be provided');
     }
 
+    this.options = { ...options };
     this.stripe = Stripe(options.secretKey);
     this.paginate = options.paginate = {};
     this.id = 'id';


### PR DESCRIPTION
This PR adds the developer's options onto the service more similarly to how most Feathers service work. This is useful for adding generic config to services such as validation schema, rate limiter, etc so they can later be accessed in hooks.