### PR TITLE
add ability to cancel a payment intent

### DIFF
--- a/lib/services/payment-intent.js
+++ b/lib/services/payment-intent.js
@@ -21,15 +21,13 @@ module.exports = class Service extends Base {
 
   _patch (id, data, params) {
     const { stripe } = this.filterParams(params);
-    const { capture, ...rest } = data;
+    const { capture, cancel, ...rest } = data;
     if (capture) {
       return this.stripe.paymentIntents.capture(id, stripe);
     }
-
     if (cancel) {
       return this.stripe.paymentIntents.cancel(id, stripe);
     }
-
     return this._update(id, rest, params);
   }
 

--- a/lib/services/payment-intent.js
+++ b/lib/services/payment-intent.js
@@ -25,6 +25,11 @@ module.exports = class Service extends Base {
     if (capture) {
       return this.stripe.paymentIntents.capture(id, stripe);
     }
+
+    if (cancel) {
+      return this.stripe.paymentIntents.cancel(id, stripe);
+    }
+
     return this._update(id, rest, params);
   }
 


### PR DESCRIPTION
Added additional condition in the patch method of the PaymentIntent service. It checks for a key "cancel"  that is passed to the data arg.

Now, one can cancel a payment intent by doing so: 

`feathers.service('stripe/payment-intent').patch(id, {
  cancel: true
});
`